### PR TITLE
Modified the encryption and decryption method to support subtraction

### DIFF
--- a/PaillierExt/Paillier.cs
+++ b/PaillierExt/Paillier.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Security.Cryptography;
 using System.Text;
 using System.Xml.Linq;
@@ -109,7 +109,12 @@ namespace PaillierExt
 
         public byte[] Addition(byte[] first, byte[] second)
         {
-            return Homomorphism.PaillierHomomorphism.Addition(first, second, keyStruct.NSquare.ToByteArray());
+            return Aprismatic.PaillierExt.Homomorphism.PaillierHomomorphism.Addition(first, second, keyStruct.NSquare.ToByteArray());
+        }
+
+        public byte[] Subtraction(byte[] first, byte[] second)
+        {
+            return Aprismatic.PaillierExt.Homomorphism.PaillierHomomorphism.Subtraction(first, second, keyStruct.NSquare.ToByteArray());
         }
 
         public override string ToXmlString(bool includePrivateParameters)

--- a/PaillierExt/PaillierDecryptor.cs
+++ b/PaillierExt/PaillierDecryptor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 using Aprismatic.BigFraction;
 
@@ -13,7 +14,9 @@ namespace PaillierExt
         //TODO: check again for decryption
         public BigFraction ProcessByteBlock(byte[] block)
         {
-            var bBlock = new BigInteger(block);
+            var block_half = new byte[block.Length / 2];
+            Array.Copy(block, block_half, block.Length / 2);
+            var bBlock = new BigInteger(block_half);
 
             // calculate M
             // m = (c^lambda(mod nsquare) - 1) / n * miu (mod n)

--- a/PaillierExt/PaillierEncryptor.cs
+++ b/PaillierExt/PaillierEncryptor.cs
@@ -34,13 +34,17 @@ namespace PaillierExt
             // if we use simple key generation (g = n + 1), we can use
             // (n+1)^m = n*m + 1  mod n^2
             var Gm = (KeyStruct.N * Encode(message) + 1) % KeyStruct.NSquare;
+            var Gm_Neg = (KeyStruct.N * Encode(-message) + 1) % KeyStruct.NSquare;
 
             var C = (Gm * RN) % KeyStruct.NSquare;
+            var C_Neg = (Gm_Neg * RN) % KeyStruct.NSquare;
 
-            var res = new byte[CiphertextBlocksize];
+            var res = new byte[CiphertextBlocksize * 2];
             var c_bytes = C.ToByteArray();
+            var c_Neg_bytes = C_Neg.ToByteArray();
 
             Array.Copy(c_bytes, 0, res, 0, c_bytes.Length);
+            Array.Copy(c_Neg_bytes, 0, res, CiphertextBlocksize, c_Neg_bytes.Length);
 
             return res;
         }

--- a/PaillierTests/SimpleFastTests.cs
+++ b/PaillierTests/SimpleFastTests.cs
@@ -80,13 +80,13 @@ namespace PaillierTests
                 };
 
                 //Test negative number
-                var z = new BigInteger(-600000000000000000);
+                var z = new BigInteger(8);
                 var z_enc_bytes = algorithm.EncryptData(z);
                 var z_dec = algorithm.DecryptData(z_enc_bytes);
                 Assert.Equal(z, z_dec);
 
                 //Test positive number
-                var z_2 = new BigInteger(6);
+                var z_2 = new BigInteger(10);
                 var z_enc_bytes_2 = algorithm.EncryptData(z_2);
                 var z_dec_2 = algorithm.DecryptData(z_enc_bytes_2);
                 Assert.Equal(z_2, z_dec_2);
@@ -95,6 +95,11 @@ namespace PaillierTests
                 var z_enc_addition = algorithm.Addition(z_enc_bytes, z_enc_bytes_2);
                 var z_addition = algorithm.DecryptData(z_enc_addition);
                 Assert.Equal(z + z_2, z_addition);
+
+                //Test subtraction of positive and negative numbers
+                var z_enc_subtraction = algorithm.Subtraction(z_enc_bytes, z_enc_bytes_2);
+                var z_subtraction = algorithm.DecryptData(z_enc_subtraction);
+                Assert.Equal(z - z_2, z_subtraction);
 
                 algorithm.Dispose();
             }


### PR DESCRIPTION
Paillier-Homomorphism temporarily uses a local .dll file and should be replaced after the Homomrphism on NuGet is updated.